### PR TITLE
feat: add visual context to AI agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,18 +34,18 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -78,15 +78,16 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -97,9 +98,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -113,15 +114,15 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -129,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -141,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -153,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -165,15 +166,24 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "glob"
@@ -189,27 +199,27 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -225,7 +235,7 @@ checksum = "d6a8f5a1e1be160ce2b669c2c495a34ade6f3a525d4afafd7370c1792070f587"
 dependencies = [
  "log",
  "rmp",
- "rmpv 0.4.7",
+ "rmpv",
  "unix_socket",
 ]
 
@@ -240,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "paste"
@@ -252,18 +262,18 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -290,22 +300,6 @@ dependencies = [
  "serde",
  "serde_bytes",
 ]
-
-[[package]]
-name = "rmpv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
-dependencies = [
- "num-traits",
- "rmp",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -349,15 +343,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -375,7 +369,7 @@ dependencies = [
  "clap",
  "glob",
  "neovim-lib",
- "rmpv 1.3.0",
+ "rmp",
  "serde",
  "serde_json",
 ]
@@ -388,9 +382,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -399,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unix_socket"
@@ -421,80 +415,21 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+name = "zmij"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "ac93432f5b761b22864c774aac244fa5c0fd877678a4c37ebf6cf42208f9c9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ keywords = ["neovim", "claude", "ai", "editor", "hook"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-anyhow = "1.0.100"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
 neovim-lib = "0.6"
-rmpv = "1.3"
 clap = { version = "4.5", features = ["derive"] }
 blake3 = "1.5"
 glob = "0.3"
+
+# Pin rmp to avoid breaking changes in 0.8.15 that break rmpv 0.4.7 (used by neovim-lib)
+rmp = "=0.8.14"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,37 @@ That's it! Now when Claude Code attempts to edit a file:
 - **Blocked**: File is in current buffer with unsaved changes
 - **Auto-refresh**: Neovim buffers are automatically reloaded after Claude Code modifies files
 
+### 3. Visual Selection Context (Optional)
+
+Want Claude Code to see what you've selected in Neovim? Add this hook:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sidekick hook"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Now when you submit a prompt to Claude Code, any visual selection in Neovim is automatically injected as context:
+
+1. Select code in Neovim (visual mode)
+2. Exit visual mode (the selection marks are preserved)
+3. Submit your prompt to Claude Code
+4. Claude sees your selection as additional context
+
+No selection? Nothing happens — the hook is a no-op.
+
 ## Usage
 
 Just use Neovim like you always do:

--- a/src/action.rs
+++ b/src/action.rs
@@ -35,6 +35,15 @@ pub struct BufferStatus {
     pub has_unsaved_changes: bool,
 }
 
+/// Editor context from visual selection
+#[derive(Debug, Clone)]
+pub struct EditorContext {
+    pub file_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub content: String,
+}
+
 /// Trait for editor actions
 pub trait Action {
     /// Get the status of a buffer
@@ -45,4 +54,7 @@ pub trait Action {
 
     /// Send a message to the editor
     fn send_message(&self, message: &str) -> anyhow::Result<()>;
+
+    /// Get the visual selection from the editor (if any)
+    fn get_visual_selection(&self) -> anyhow::Result<Option<EditorContext>>;
 }

--- a/src/action/neovim/connection.rs
+++ b/src/action/neovim/connection.rs
@@ -48,3 +48,18 @@ where
 
     any_processed.then(|| result.unwrap_or_else(|acc| acc))
 }
+
+/// Find first non-None result from any Neovim instance
+pub fn find_first<T, F>(socket_paths: &[PathBuf], mut f: F) -> Option<T>
+where
+    F: FnMut(&mut Neovim) -> Result<Option<T>>,
+{
+    for path in socket_paths {
+        if let Ok(mut nvim) = connect(path)
+            && let Ok(Some(result)) = f(&mut nvim)
+        {
+            return Some(result);
+        }
+    }
+    None
+}

--- a/src/action/neovim/lua.rs
+++ b/src/action/neovim/lua.rs
@@ -48,16 +48,25 @@ pub fn send_notification_lua(message: &str) -> String {
 /// Lua code to get visual selection from the current buffer
 pub fn get_visual_selection_lua() -> &'static str {
     r#"
-    local start_pos = vim.fn.getpos("'<")
-    local end_pos = vim.fn.getpos("'>")
+    local mode = vim.fn.mode()
+    local start_pos, end_pos, sel_type
+
+    if mode:match('[vV\22]') then
+        -- Currently in visual mode: use live selection
+        start_pos = vim.fn.getpos("v")
+        end_pos = vim.fn.getpos(".")
+        sel_type = mode:sub(1, 1)
+    else
+        -- Not in visual mode: use last visual selection marks
+        start_pos = vim.fn.getpos("'<")
+        end_pos = vim.fn.getpos("'>")
+        sel_type = vim.fn.visualmode()
+    end
 
     -- Check if visual marks are set (line numbers > 0)
     if start_pos[2] == 0 or end_pos[2] == 0 then
         return nil
     end
-
-    local start_line = start_pos[2]
-    local end_line = end_pos[2]
 
     -- Get current buffer file path
     local file_path = vim.api.nvim_buf_get_name(0)
@@ -65,9 +74,13 @@ pub fn get_visual_selection_lua() -> &'static str {
         return nil
     end
 
-    -- Get the lines (0-indexed API, so subtract 1 from start)
-    local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+    -- getregion handles all visual modes (v, V, Ctrl-V) correctly
+    local lines = vim.fn.getregion(start_pos, end_pos, { type = sel_type })
     local content = table.concat(lines, "\n")
+
+    -- Get ordered line numbers
+    local start_line = math.min(start_pos[2], end_pos[2])
+    local end_line = math.max(start_pos[2], end_pos[2])
 
     return vim.fn.json_encode({
         file_path = file_path,

--- a/src/action/neovim/lua.rs
+++ b/src/action/neovim/lua.rs
@@ -44,3 +44,36 @@ pub fn send_notification_lua(message: &str) -> String {
         message.replace('"', r#"\""#)
     )
 }
+
+/// Lua code to get visual selection from the current buffer
+pub fn get_visual_selection_lua() -> &'static str {
+    r#"
+    local start_pos = vim.fn.getpos("'<")
+    local end_pos = vim.fn.getpos("'>")
+
+    -- Check if visual marks are set (line numbers > 0)
+    if start_pos[2] == 0 or end_pos[2] == 0 then
+        return nil
+    end
+
+    local start_line = start_pos[2]
+    local end_line = end_pos[2]
+
+    -- Get current buffer file path
+    local file_path = vim.api.nvim_buf_get_name(0)
+    if file_path == "" then
+        return nil
+    end
+
+    -- Get the lines (0-indexed API, so subtract 1 from start)
+    local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+    local content = table.concat(lines, "\n")
+
+    return vim.fn.json_encode({
+        file_path = file_path,
+        start_line = start_line,
+        end_line = end_line,
+        content = content
+    })
+    "#
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -48,7 +48,6 @@ pub fn handle_hook() -> anyhow::Result<()> {
         Hook::Tool(h) => match h.hook_event_name {
             HookEvent::PreToolUse => handle_pre_tool_use(&h.tool, nvim_action.as_ref()),
             HookEvent::PostToolUse => handle_post_tool_use(&h.tool, nvim_action.as_ref()),
-            HookEvent::UserPromptSubmit => HookOutput::new(), // shouldn't happen
         },
         Hook::UserPrompt => handle_user_prompt_submit(nvim_action.as_ref()),
     };
@@ -105,7 +104,8 @@ fn handle_user_prompt_submit(nvim_action: Option<&NeovimAction>) -> HookOutput {
         ctx.file_path, ctx.start_line, ctx.end_line, ctx.content
     );
 
-    HookOutput::new().with_additional_context(context)
+    HookOutput::new()
+        .with_additional_context(context)
 }
 
 /// Check if buffer has unsaved modifications and block if necessary

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -104,8 +104,7 @@ fn handle_user_prompt_submit(nvim_action: Option<&NeovimAction>) -> HookOutput {
         ctx.file_path, ctx.start_line, ctx.end_line, ctx.content
     );
 
-    HookOutput::new()
-        .with_additional_context(context)
+    HookOutput::new().with_additional_context(context)
 }
 
 /// Check if buffer has unsaved modifications and block if necessary

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -37,7 +37,6 @@ use anyhow::Context;
 pub enum HookEvent {
     PreToolUse,
     PostToolUse,
-    UserPromptSubmit,
 }
 
 /// Hook input for tool-related events (PreToolUse, PostToolUse)
@@ -99,9 +98,12 @@ pub fn parse_hook(input: &str) -> anyhow::Result<Hook> {
 
     match event_name {
         "UserPromptSubmit" => Ok(Hook::UserPrompt),
-        _ => {
+        "PreToolUse" | "PostToolUse" => {
             let hook: ToolHook = serde_json::from_str(input).context("Invalid tool hook")?;
             Ok(Hook::Tool(hook))
+        }
+        _ => {
+            anyhow::bail!("Invalid hook received")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add visual selection context support - AI agents can now see what text is visually selected in Neovim
- Pin rmp dependency to avoid breaking neovim-lib compatibility
- Fix Lua script for retrieving visual selection location

## Test plan
- [ ] Verify visual selection context is captured when text is selected in Neovim
- [ ] Test that hook handler correctly includes visual context in responses
- [ ] Confirm backward compatibility with existing buffer operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)